### PR TITLE
Central Ollama gate: filter every opportunity before save

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -22,6 +22,11 @@ class Config:
     AI_FILTER_TIMEOUT = int(os.environ.get('AI_FILTER_TIMEOUT', '120'))  # 120s default (llama loads slowly on first run)
     AI_FILTER_FALLBACK = os.environ.get('AI_FILTER_FALLBACK', 'true').lower() == 'true'
     AI_FILTER_MIN_CONFIDENCE = float(os.environ.get('AI_FILTER_MIN_CONFIDENCE', '0.7'))  # Reject AI "true" if confidence below this
+    # When True, reject opportunities when Ollama is unavailable (no keyword fallback) - avoids false positives
+    AI_FILTER_REJECT_ON_ERROR = os.environ.get('AI_FILTER_REJECT_ON_ERROR', 'true').lower() == 'true'
+    # Comma-separated source names that skip AI filter (e.g. "jooble,authentic_jobs" - API job boards are usually clean)
+    SOURCES_SKIP_AI_FILTER_STR = os.environ.get('SOURCES_SKIP_AI_FILTER', '')
+    SOURCES_SKIP_AI_FILTER = [s.strip().lower() for s in SOURCES_SKIP_AI_FILTER_STR.split(',') if s.strip()]
     
     @staticmethod
     def get_ollama_url():

--- a/api/scheduler.py
+++ b/api/scheduler.py
@@ -68,8 +68,9 @@ def fetch_all_opportunities() -> Dict:
     FetcherConfig = get_fetcher_config()
     fetcher_classes = get_fetchers()
     
-    # Import deduplicator function - it will get db and Opportunity from Flask app context
+    # Import deduplicator and AI filter - every opportunity must pass AI gate before save
     from deduplicator import save_or_update_opportunity
+    from ai_filter import should_save_opportunity
     
     # #region agent log
     try:
@@ -260,6 +261,9 @@ def fetch_all_opportunities() -> Dict:
             
             for idx, opp_dict in enumerate(opportunities):
                 try:
+                    # Central AI gate: only save if Ollama (or fallback) says it's a real opportunity
+                    if not should_save_opportunity(opp_dict):
+                        continue  # Skip this opportunity (discussion, question, or rejected)
                     # #region agent log
                     try:
                         with open(log_path, 'a') as f:


### PR DESCRIPTION
- Scheduler runs should_save_opportunity() on each fetched item before save
- Only items classified as real opportunities by Ollama (or fallback) are stored
- ai_filter: add should_save_opportunity(), keyword_based_filter_fallback()
- config: AI_FILTER_REJECT_ON_ERROR (reject when Ollama down), SOURCES_SKIP_AI_FILTER
- RSS/Reddit fetchers: remove per-fetcher filtering; rely on central gate
- Reduces false positives (e.g. Reddit discussions) from appearing in app